### PR TITLE
Remove subprocess.check_output text argument for Python <3.7 support

### DIFF
--- a/sis-install.py
+++ b/sis-install.py
@@ -246,7 +246,7 @@ class Monitor:
 			else:
 				err = self.err
 		try:
-			return subprocess.check_output(cmd, stderr=err, shell=True, text=True)
+			return subprocess.check_output(cmd, stderr=err, shell=True, universal_newlines=True)
 		except subprocess.CalledProcessError as e:
 			self.log(str(e))
 			return None


### PR DESCRIPTION
See https://stackoverflow.com/questions/52663518/python-subprocess-popen-doesnt-take-text-argument
See https://github.com/jordr/otawa-project/pull/1

Fixes this error:
```
❯ python3 ./otawa-install.py
WARNING: please use otawa/bin/otawa-install.py instead!
testing command c++ ... [OK]
testing command flex ... [OK]
testing command bison ... [OK]
testing command git ... [OK]
testing command cmake ... [OK]
testing command cc ... [OK]
testing library  libxml2 ... [FAILED]
testing library  libxslt ... [FAILED]
ERROR: 2 dependency(ies) failed: aborting.
```

Removing `text=True` does not work because of:

```
build.log:3:cflags = b'-I/usr/include/libxml2'
build.log:5:running /usr/bin/cc /tmp/tmpl3p59_33.c -o /tmp/tmp3m_6rh2e b'-I/usr/include/libxml2' b'-lxml2'
build.log:6:cc: error: b-I/usr/include/libxml2: No such file or directory
build.log:8:cflags = b'-I/usr/include/libxml2'
build.log:10:running /usr/bin/cc /tmp/tmpmhknednk.c -o /tmp/tmpuk9p7pfe b'-I/usr/include/libxml2' b'-lxslt -lxml2'
build.log:11:cc: error: b-I/usr/include/libxml2: No such file or directory
```

New log:
```
❯ python3.8 ./otawa-install.py
WARNING: please use otawa/bin/otawa-install.py instead!
testing command c++ ... [OK]
testing command flex ... [OK]
testing command bison ... [OK]
testing command git ... [OK]
testing command cmake ... [OK]
testing command cc ... [OK]
testing library  libxml2 ... [OK]
testing library  libxslt ... [OK]
downloading gel ... [OK]
building gel ... [OK]
installing gel ... [OK]
downloading elm ... [OK]
building elm ... [OK]
installing elm ... [OK]
downloading otawa ... [OK]
building otawa ... [OK]
installing otawa ... [OK]
```